### PR TITLE
Eris/image popup

### DIFF
--- a/components/image-popup.tsx
+++ b/components/image-popup.tsx
@@ -5,7 +5,13 @@ import {
   DialogHeader,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { DialogPortal, DialogTitle } from '@radix-ui/react-dialog';
+import {
+  DialogDescription,
+  DialogPortal,
+  DialogTitle,
+} from '@radix-ui/react-dialog';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+
 import { useState } from 'react';
 
 export default function ImagePopup({
@@ -13,7 +19,6 @@ export default function ImagePopup({
   alt,
 }: { src?: string; alt?: string }) {
   const [isOpen, setIsOpen] = useState(false);
-  console.log(alt);
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -27,11 +32,14 @@ export default function ImagePopup({
               <span>{alt}</span>
             </DialogTitle>
           </DialogHeader>
+          <VisuallyHidden>
+            <DialogDescription>{alt}</DialogDescription>
+          </VisuallyHidden>
           <div className="relative w-full">
             <img
               src={src || ''}
               alt={alt || ''}
-              className="w-full h-auto max-h-[90vh] object-contain"
+              className="w-full h-auto max-h-[85vh] object-contain"
             />
           </div>
         </DialogContent>

--- a/components/image-popup.tsx
+++ b/components/image-popup.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable @next/next/no-img-element */
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { DialogPortal, DialogTitle } from '@radix-ui/react-dialog';
+import { useState } from 'react';
+
+export default function ImagePopup({
+  src,
+  alt,
+}: { src?: string; alt?: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+  console.log(alt);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <img src={src || ''} alt={alt || ''} className="cursor-pointer" />
+      </DialogTrigger>
+      <DialogPortal>
+        <DialogContent className="max-w-6xl" onClick={() => setIsOpen(false)}>
+          <DialogHeader>
+            <DialogTitle asChild>
+              <span>{alt}</span>
+            </DialogTitle>
+          </DialogHeader>
+          <div className="relative w-full">
+            <img
+              src={src || ''}
+              alt={alt || ''}
+              className="w-full h-auto max-h-[90vh] object-contain"
+            />
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+}

--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -4,6 +4,7 @@ import remarkGfm from 'remark-gfm';
 import Citation from './citation';
 import { CodeBlock } from './code-block';
 import Link from 'next/link';
+import ImagePopup from './image-popup';
 
 const components: Partial<Components> = {
   // @ts-expect-error
@@ -96,6 +97,9 @@ const components: Partial<Components> = {
         {children}
       </h6>
     );
+  },
+  img: ({ src, alt }) => {
+    return <ImagePopup src={src} alt={alt} />;
   },
 };
 

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}


### PR DESCRIPTION
Images in the chat can now be clicked to be enlargened.
This pull request introduces a new `ImagePopup` component and integrates it into the markdown rendering process. It also includes the creation of a new `Dialog` component to support the popup functionality.

New `ImagePopup` component:

* [`components/image-popup.tsx`](diffhunk://#diff-f2be76b66b0039a4d4098e14437c7d435c2508e23e585ec1bfa61862a52d4022R1-R49): Added a new `ImagePopup` component that uses the `Dialog` component to display images in a modal popup.

Integration into markdown rendering:

* [`components/markdown.tsx`](diffhunk://#diff-82c352bb196e10446462f63f8b3d39a12ce8d991f7aca0fb06e8c0eef5460147R7): Imported the `ImagePopup` component and modified the `components` object to use `ImagePopup` for rendering images. [[1]](diffhunk://#diff-82c352bb196e10446462f63f8b3d39a12ce8d991f7aca0fb06e8c0eef5460147R7) [[2]](diffhunk://#diff-82c352bb196e10446462f63f8b3d39a12ce8d991f7aca0fb06e8c0eef5460147R101-R103)

New `Dialog` component:

* [`components/ui/dialog.tsx`](diffhunk://#diff-ba221113eac7c71476db82fb5db4c480fd556a56ed1ddd8e77aa8b85f67628bfR1-R122): Created a new `Dialog` component using Radix UI's dialog primitives, including `Dialog`, `DialogTrigger`, `DialogPortal`, `DialogContent`, `DialogHeader`, `DialogTitle`, and `DialogDescription`.