### PR TITLE
Mehmet/web 37 vercel add web search toggle

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -30,10 +30,10 @@ export function Chat({
   isReadonly: boolean;
 }) {
   const { mutate } = useSWRConfig();
+  const [searchWeb, setSearchWeb] = useState(false);
 
   const viewConfig = useViewConfig();
-  const { chatConfig, endpointConfig, adminChatConfig } =
-    useChatSettingsContext();
+  const { chatConfig, endpointConfig } = useChatSettingsContext();
   const voteUrl = viewConfig.isIframe ? null : `/api/vote?chatId=${id}`;
   const { data: votes } = useSWR<Array<Vote>>(voteUrl, fetcher);
 
@@ -52,7 +52,7 @@ export function Chat({
     reload,
   } = useChat({
     id,
-    body: { id },
+    body: { id, enableWebSearch: searchWeb },
     api: endpointConfig.endpoint,
     headers: {
       ...(endpointConfig.subscriptionKey
@@ -108,6 +108,7 @@ export function Chat({
               messages={messages}
               setMessages={setMessages}
               append={append}
+              setSearchWeb={setSearchWeb}
             />
           )}
         </form>

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -43,9 +43,9 @@ interface PureMultimodalInputProps {
   stop: () => void;
   attachments: Array<Attachment>;
   setAttachments: Dispatch<SetStateAction<Array<Attachment>>>;
-
   messages: Array<Message>;
   setMessages: Dispatch<SetStateAction<Array<Message>>>;
+  setSearchWeb: Dispatch<SetStateAction<boolean>>;
   append: (
     message: Message | CreateMessage,
     chatRequestOptions?: ChatRequestOptions,
@@ -76,6 +76,7 @@ function PureMultimodalInput({
   append,
   handleSubmit,
   className,
+  setSearchWeb,
 }: PureMultimodalInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
@@ -305,7 +306,9 @@ function PureMultimodalInput({
               isLoading={isLoading}
             />
           )}
-          {adminChatConfig.showWebSearch && <WebToggleButton />}
+          {adminChatConfig.showWebSearch && (
+            <WebToggleButton setSearchWeb={setSearchWeb} />
+          )}
         </div>
       </div>
 

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -33,6 +33,7 @@ import { PreviewAttachment } from './preview-attachment';
 import { SuggestedActions } from './suggested-actions';
 import { Button } from './ui/button';
 import { Textarea } from './ui/textarea';
+import WebToggleButton from './web-toggle-button';
 
 interface PureMultimodalInputProps {
   chatId: string;
@@ -296,14 +297,17 @@ function PureMultimodalInput({
         }}
       />
 
-      {adminChatConfig.showFileUpload && (
-        <div className="absolute bottom-0 p-2 w-fit flex flex-row justify-start">
-          <AttachmentsButton
-            fileInputRef={fileInputRef}
-            isLoading={isLoading}
-          />
+      <div className="absolute bottom-0 p-2 w-fit flex flex-row justify-start">
+        <div className="flex gap-x-2 items-center">
+          {adminChatConfig.showFileUpload && (
+            <AttachmentsButton
+              fileInputRef={fileInputRef}
+              isLoading={isLoading}
+            />
+          )}
+          {adminChatConfig.showWebSearch && <WebToggleButton />}
         </div>
-      )}
+      </div>
 
       <div className="absolute bottom-0 p-2 left-1/2 -translate-x-1/2 sm:translate-y-1">
         <PoweredBy poweredByName={adminChatConfig.poweredBy} />

--- a/components/web-toggle-button.tsx
+++ b/components/web-toggle-button.tsx
@@ -12,7 +12,7 @@ export default function WebToggleButton() {
 
   return (
     <Button
-      className={`p-[7px] h-fit rounded-md ${isActive ? 'bg-blue-600/40' : ''} dark:border-zinc-700 hover:dark:bg-zinc-900 hover:bg-zinc-200`}
+      className={`p-[7px] h-fit rounded-md ${isActive ? 'bg-blue-400/40 dark:bg-blue-600/40 hover:bg-blue-300/40 hover:dark:bg-blue-700/40' : 'hover:dark:bg-zinc-900 hover:bg-zinc-300'} dark:border-zinc-700`}
       onClick={(event) => {
         event.preventDefault();
         handleButtonClick();
@@ -20,7 +20,7 @@ export default function WebToggleButton() {
       variant="ghost"
     >
       <Globe
-        className={`transition-color ${isActive ? 'text-blue-400' : ''}`}
+        className={`transition-color ${isActive ? 'text-blue-600 dark:text-blue-400' : ''}`}
       />
       {isActive && (
         <motion.span

--- a/components/web-toggle-button.tsx
+++ b/components/web-toggle-button.tsx
@@ -1,13 +1,17 @@
-import { Globe } from 'lucide-react';
-import { Button } from './ui/button';
-import { useState } from 'react';
 import { motion } from 'framer-motion';
+import { Globe } from 'lucide-react';
+import { type Dispatch, type SetStateAction, useState } from 'react';
+import { Button } from './ui/button';
 
-export default function WebToggleButton() {
+export default function WebToggleButton({
+  setSearchWeb,
+}: { setSearchWeb: Dispatch<SetStateAction<boolean>> }) {
   const [isActive, setActive] = useState(false);
 
   function handleButtonClick() {
-    setActive(!isActive);
+    const newValue = !isActive;
+    setActive(newValue);
+    setSearchWeb(newValue);
   }
 
   return (
@@ -27,7 +31,6 @@ export default function WebToggleButton() {
           className="flex items-center h-4 text-blue-600 dark:text-blue-400"
           initial={{ scale: 0 }}
           animate={{ scale: 1 }}
-          exit={{ scale: 0, transition: { delay: 0.4 } }}
         >
           Web
         </motion.span>

--- a/components/web-toggle-button.tsx
+++ b/components/web-toggle-button.tsx
@@ -1,0 +1,37 @@
+import { Globe } from 'lucide-react';
+import { Button } from './ui/button';
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+
+export default function WebToggleButton() {
+  const [isActive, setActive] = useState(false);
+
+  function handleButtonClick() {
+    setActive(!isActive);
+  }
+
+  return (
+    <Button
+      className={`p-[7px] h-fit rounded-md ${isActive ? 'bg-blue-600/40' : ''} dark:border-zinc-700 hover:dark:bg-zinc-900 hover:bg-zinc-200`}
+      onClick={(event) => {
+        event.preventDefault();
+        handleButtonClick();
+      }}
+      variant="ghost"
+    >
+      <Globe
+        className={`transition-color ${isActive ? 'text-blue-400' : ''}`}
+      />
+      {isActive && (
+        <motion.span
+          className="flex items-center h-4 text-blue-600 dark:text-blue-400"
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          exit={{ scale: 0, transition: { delay: 0.4 } }}
+        >
+          Web
+        </motion.span>
+      )}
+    </Button>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable web search functionality within the chat component. The main changes include adding a toggle button for web search and updating the chat component to handle this new feature.

Changes to `Chat` component:

* Added a new state variable `searchWeb` to manage the web search toggle.
* Updated the chat request body to include the `enableWebSearch` parameter based on the `searchWeb` state.
* Passed the `setSearchWeb` function to the `PureMultimodalInput` component.

Changes to `PureMultimodalInput` component:

* Imported the new `WebToggleButton` component.
* Added `setSearchWeb` as a prop to the `PureMultimodalInputProps` interface.
* Passed the `setSearchWeb` function to the `WebToggleButton` component.
* Added the `WebToggleButton` to the UI, conditionally rendered based on `adminChatConfig.showWebSearch`.

New `WebToggleButton` component:

* Created a new `WebToggleButton` component to manage the web search toggle state and update the parent component's state.