### PR TITLE
feat(message): add a loading spinner when waiting for message

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -13,7 +13,7 @@ import equal from 'fast-deep-equal';
 import AssistantAvatar from './assistant-avatar';
 import { DocumentToolCall, DocumentToolResult } from './document';
 import { DocumentPreview } from './document-preview';
-import { PencilEditIcon } from './icons';
+import { LoaderIcon, PencilEditIcon } from './icons';
 import { Markdown } from './markdown';
 import { MessageActions } from './message-actions';
 import { MessageEditor } from './message-editor';
@@ -258,8 +258,10 @@ export const ThinkingMessage = ({ chatLogo }: { chatLogo?: string }) => {
       >
         <AssistantAvatar chatLogo={chatLogo} />
 
-        <div className="flex flex-col gap-2 w-full">
-          <div className="flex flex-col gap-4 text-muted-foreground">...</div>
+        <div className="flex flex-col justify-center gap-2">
+          <div className="animate-spin">
+            <LoaderIcon />
+          </div>
         </div>
       </div>
     </motion.div>


### PR DESCRIPTION
This pull request includes changes to the `components/message.tsx` file to enhance the user interface by adding a loading spinner icon and modifying the layout of the `ThinkingMessage` component.

UI Improvements:

* [`components/message.tsx`](diffhunk://#diff-119f563915750907b6691f79e59a4486ae1d7e2dc99b18d0b6c425da66dc0a78L16-R16): Imported `LoaderIcon` from the `icons` module to use it in the `ThinkingMessage` component.
* [`components/message.tsx`](diffhunk://#diff-119f563915750907b6691f79e59a4486ae1d7e2dc99b18d0b6c425da66dc0a78L261-R264): Updated the `ThinkingMessage` component to include a spinning `LoaderIcon` and adjusted the layout to center the icon.