### PR TITLE
refactor(multimodal-input): dont save input in local storage when in …

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -104,8 +104,9 @@ function PureMultimodalInput({
   }, []);
 
   useEffect(() => {
+    if (viewConfig.isIframe) return;
     setLocalStorageInput(input);
-  }, [input, setLocalStorageInput]);
+  }, [input, setLocalStorageInput, viewConfig.isIframe]);
 
   const handleInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(event.target.value);


### PR DESCRIPTION
This pull request includes a small but important change to the `PureMultimodalInput` component in `components/multimodal-input.tsx`. The change ensures that the `setLocalStorageInput` function is not called when the `viewConfig.isIframe` flag is true, improving behavior in iframe contexts.

* [`components/multimodal-input.tsx`](diffhunk://#diff-9df7a8422a0b5bfedc8e2e6afcaec2d632fe43a9d784849702bb3f8d68fbb8e6R107-R109): Added a conditional check for `viewConfig.isIframe` in the `useEffect` hook to prevent calling `setLocalStorageInput` when the component is rendered inside an iframe. Updated the dependency array to include `viewConfig.isIframe`.…an iframe